### PR TITLE
[PR] The proj files have been updated to enable SourceLink

### DIFF
--- a/src/CodeFriendly.Core.AutoMapper/CodeFriendly.Core.AutoMapper.csproj
+++ b/src/CodeFriendly.Core.AutoMapper/CodeFriendly.Core.AutoMapper.csproj
@@ -11,7 +11,16 @@
             <RepositoryType>git</RepositoryType>
             <PackageIconUrl>https://raw.githubusercontent.com/friendly-tech/Friendly/master/engineer.png</PackageIconUrl>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    </PropertyGroup>
+    
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
     <ItemGroup>
       <PackageReference Include="AutoMapper">

--- a/src/CodeFriendly.Core/CodeFriendly.Core.csproj
+++ b/src/CodeFriendly.Core/CodeFriendly.Core.csproj
@@ -10,7 +10,16 @@
         <RepositoryType>git</RepositoryType>
         <PackageIconUrl>https://raw.githubusercontent.com/friendly-tech/Friendly/master/engineer.png</PackageIconUrl>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    </PropertyGroup>
+    
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
     <ItemGroup>
       <PackageReference Include="Microsoft.Extensions.DependencyInjection">

--- a/src/CodeFriendly.Filtering.Abstractions/CodeFriendly.Filtering.Abstractions.csproj
+++ b/src/CodeFriendly.Filtering.Abstractions/CodeFriendly.Filtering.Abstractions.csproj
@@ -11,6 +11,15 @@
             <RepositoryType>git</RepositoryType>
             <PackageIconUrl>https://raw.githubusercontent.com/friendly-tech/Friendly/master/engineer.png</PackageIconUrl>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    </PropertyGroup>
+    
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
 </Project>

--- a/src/CodeFriendly.Filtering.AspNet/CodeFriendly.Filtering.AspNet.csproj
+++ b/src/CodeFriendly.Filtering.AspNet/CodeFriendly.Filtering.AspNet.csproj
@@ -10,7 +10,16 @@
         <RepositoryType>git</RepositoryType>
         <PackageIconUrl>https://raw.githubusercontent.com/friendly-tech/Friendly/master/engineer.png</PackageIconUrl>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    </PropertyGroup>
+    
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
     <ItemGroup>
       <ProjectReference Include="..\CodeFriendly.Filtering.Abstractions\CodeFriendly.Filtering.Abstractions.csproj" />

--- a/src/CodeFriendly.Filtering.EntityFramework/CodeFriendly.Filtering.EntityFramework.csproj
+++ b/src/CodeFriendly.Filtering.EntityFramework/CodeFriendly.Filtering.EntityFramework.csproj
@@ -10,7 +10,16 @@
         <RepositoryType>git</RepositoryType>
         <PackageIconUrl>https://raw.githubusercontent.com/friendly-tech/Friendly/master/engineer.png</PackageIconUrl>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    </PropertyGroup>
+    
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
     <ItemGroup>
       <PackageReference Include="AutoMapper">

--- a/src/CodeFriendly.Filtering.OData/CodeFriendly.Filtering.OData.csproj
+++ b/src/CodeFriendly.Filtering.OData/CodeFriendly.Filtering.OData.csproj
@@ -10,7 +10,16 @@
         <RepositoryType>git</RepositoryType>
         <PackageIconUrl>https://raw.githubusercontent.com/friendly-tech/Friendly/master/engineer.png</PackageIconUrl>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    </PropertyGroup>
+    
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
     <ItemGroup>
       <ProjectReference Include="..\CodeFriendly.Filtering.Abstractions\CodeFriendly.Filtering.Abstractions.csproj" />

--- a/src/CodeFriendly.Filtering/CodeFriendly.Filtering.csproj
+++ b/src/CodeFriendly.Filtering/CodeFriendly.Filtering.csproj
@@ -11,7 +11,16 @@
         <RepositoryType>git</RepositoryType>
         <PackageIconUrl>https://raw.githubusercontent.com/friendly-tech/Friendly/master/engineer.png</PackageIconUrl>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    </PropertyGroup>
+    
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
     <ItemGroup>
       <ProjectReference Include="..\CodeFriendly.Core\CodeFriendly.Core.csproj" />

--- a/src/CodeFriendly.Patch.Abstractions/CodeFriendly.Patch.Abstractions.csproj
+++ b/src/CodeFriendly.Patch.Abstractions/CodeFriendly.Patch.Abstractions.csproj
@@ -10,6 +10,15 @@
         <RepositoryType>git</RepositoryType>
         <PackageIconUrl>https://raw.githubusercontent.com/friendly-tech/Friendly/master/engineer.png</PackageIconUrl>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    </PropertyGroup>
+    
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
 </Project>

--- a/src/CodeFriendly.Patch/CodeFriendly.Patch.csproj
+++ b/src/CodeFriendly.Patch/CodeFriendly.Patch.csproj
@@ -10,7 +10,16 @@
         <RepositoryType>git</RepositoryType>
         <PackageIconUrl>https://raw.githubusercontent.com/friendly-tech/Friendly/master/engineer.png</PackageIconUrl>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    </PropertyGroup>
+    
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
     <ItemGroup>
       <PackageReference Include="AutoMapper">

--- a/src/CodeFriendly.ServiceModel.Abstractions/CodeFriendly.ServiceModel.Abstractions.csproj
+++ b/src/CodeFriendly.ServiceModel.Abstractions/CodeFriendly.ServiceModel.Abstractions.csproj
@@ -10,7 +10,16 @@
         <RepositoryType>git</RepositoryType>
         <PackageIconUrl>https://raw.githubusercontent.com/friendly-tech/Friendly/master/engineer.png</PackageIconUrl>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    </PropertyGroup>
+    
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
     <ItemGroup>
       <ProjectReference Include="..\CodeFriendly.Filtering.Abstractions\CodeFriendly.Filtering.Abstractions.csproj" />

--- a/src/CodeFriendly.ServiceModel.EntityFramework/CodeFriendly.ServiceModel.EntityFramework.csproj
+++ b/src/CodeFriendly.ServiceModel.EntityFramework/CodeFriendly.ServiceModel.EntityFramework.csproj
@@ -10,7 +10,16 @@
         <RepositoryType>git</RepositoryType>
         <PackageIconUrl>https://raw.githubusercontent.com/friendly-tech/Friendly/master/engineer.png</PackageIconUrl>
         <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
-    </PropertyGroup>
+    
+    <PublishRepositoryUrl>true</PublishRepositoryUrl>
+    <IncludeSymbols>true</IncludeSymbols>
+    <SymbolPackageFormat>snupkg</SymbolPackageFormat>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
+  </ItemGroup>
+
 
     <ItemGroup>
       <ProjectReference Include="..\CodeFriendly.Filtering.EntityFramework\CodeFriendly.Filtering.EntityFramework.csproj" />


### PR DESCRIPTION
CSProj files have been updated to enable SourceLink in your nuget
---

*[This pull request was created with an automated workflow]*

I noticed that your repository and Nuget package are important for our .NET community, but you still haven't enabled SourceLink.

**We have to take 2 steps:**
1) Please approve this pull request and make .NET a better place for .NET developers and their debugging.
2) **Then just upload the .snupkg file** to https://www.nuget.org/ (now you can find the snupkg file along with the .nuget file)

You can find more information about SourceLine at the following links  
https://github.com/dotnet/sourcelink
https://www.hanselman.com/blog/ExploringNETCoresSourceLinkSteppingIntoTheSourceCodeOfNuGetPackagesYouDontOwn.aspx

If you are interesting about this automated workflow and how it works  
https://github.com/JTOne123/GitHubMassUpdater

*If you notice any flaws, please comment and I will try to make fixes manually*
